### PR TITLE
Don't emit spurious empty lines

### DIFF
--- a/linestream.js
+++ b/linestream.js
@@ -38,10 +38,7 @@ LineStream.prototype._transform = function(chunk, encoding, done) {
   var data = this._buff + chunk.toString('utf8');
   var lines = data.split(/\r?\n|\r(?!\n)/);
 
-  if (!data.match(/(\r?\n|\r(?!\n))$/))
-    this._buff = lines.pop();
-  else
-    this._buff = '';
+  this._buff = lines.pop();
 
   var self = this;
 


### PR DESCRIPTION
data.split will always create a last line in the array, even if that
line is empty. That is, if we split `"foo\n"`, we will end up with the
array `["foo",""]`. We should not emit this empty line as it is merely the
start of the next line, and is not terminated until the next newline
marker.

It turns out that the correct thing to do is to take the last item from
the split and set this._buff to its value, whether or not the input
chunk is terminated with a newline. Thankfully, this makes the code
simpler.
