### PR TITLE
data events emitted with empty strings

### DIFF
--- a/linestream.js
+++ b/linestream.js
@@ -46,7 +46,10 @@ LineStream.prototype._transform = function(chunk, encoding, done) {
   var self = this;
 
   lines.forEach(function (line) {
-    self._line(line);
+    // Note this may be empty as "lines" might be:
+    // ['foo', '']
+    if (line)
+      self._line(line);
   });
 
   done();


### PR DESCRIPTION
I hit this streaming back a directory listing from Manta, as an example test case.  For each "real line", the `lines` array ends up having a length of two, where the second entry is always `''`.
